### PR TITLE
Fixed the way of finding the padding

### DIFF
--- a/src/main/kotlin/id/walt/services/essif/userwallet/UserWalletService.kt
+++ b/src/main/kotlin/id/walt/services/essif/userwallet/UserWalletService.kt
@@ -258,7 +258,7 @@ object UserWalletService {
 
         val accessTokenBytes = c.doFinal(encryptedPayload.cipherText)
 
-        var endInx = accessTokenBytes.findFirst { b -> (b.toInt() == 5) }
+        val endInx = accessTokenBytes.findFirst { b -> (b.toInt() in 1..16) }
 
         val accessTokenRespStr = String(accessTokenBytes.slice(0 until endInx).toByteArray())
 


### PR DESCRIPTION
From what i have been testing, padding is usually 6 or 7 now, so the access token cannot be parsed anymore. Anyway, i think it's better to adopt a safer solution like looking for all possible padding values (1 to 16).