### PR TITLE
Fixed 400 Bad Request when registering did in ebsi ledger

### DIFF
--- a/src/main/kotlin/id/walt/services/essif/didebsi/WaltIdDidEbsiService.kt
+++ b/src/main/kotlin/id/walt/services/essif/didebsi/WaltIdDidEbsiService.kt
@@ -22,6 +22,7 @@ import org.web3j.rlp.RlpEncoder
 import org.web3j.rlp.RlpList
 import org.web3j.utils.Numeric
 import java.math.BigInteger
+import java.util.*
 import kotlin.random.Random
 
 open class WaltIdDidEbsiService : DidEbsiService() {
@@ -114,7 +115,12 @@ open class WaltIdDidEbsiService : DidEbsiService() {
             .add(chainId.multiply(BigInteger.TWO))
             .add(BigInteger.valueOf(35L))
 
-        signatureData = Sign.SignatureData(v.toByteArray(), sig.r.toByteArray(), sig.s.toByteArray())
+        var sigR = sig.r.toByteArray()
+        if (sigR.size == 33) {
+            sigR = Arrays.copyOfRange(sigR, 1, 33)
+        }
+
+        signatureData = Sign.SignatureData(v.toByteArray(), sigR, sig.s.toByteArray())
         rlpList = RlpList(TransactionEncoder.asRlpValues(rawTransaction, signatureData))
 
         return SignedTransaction(


### PR DESCRIPTION
I found out the reason behind the **Client request(https://api.preprod.ebsi.eu/did-registry/v2/jsonrpc) invalid: 400 Bad Request. Text: "{"jsonrpc":"2.0","error":{"code":-32600,"message":"value out of range (argument=\"value\", value=32, code=INVALID_ARGUMENT, version=bytes/5.3.0)"},"id":906}"** error that sometimes appear when registering a did.

For some reason (still unknown to me), sometimes the **r** component of the signature has a **0x00** byte at the start, making it a 33 length bytearray. Since 32 bytes is the only allowed length for the **r** component, the EBSI backend was returning this error every time this byte was present.