### PR TITLE
Implemented did ebsi method v2

### DIFF
--- a/src/main/kotlin/id/walt/cli/DidCommand.kt
+++ b/src/main/kotlin/id/walt/cli/DidCommand.kt
@@ -13,13 +13,17 @@ import com.github.ajalt.clikt.parameters.options.flag
 import com.github.ajalt.clikt.parameters.options.option
 import com.github.ajalt.clikt.parameters.options.required
 import com.github.ajalt.clikt.parameters.types.choice
+import com.github.ajalt.clikt.parameters.types.int
 import com.github.ajalt.clikt.parameters.types.path
 import id.walt.common.prettyPrint
 import id.walt.crypto.KeyAlgorithm
 import id.walt.model.DidMethod
+import id.walt.model.DidMethod.*
 import id.walt.model.DidUrl
 import id.walt.services.crypto.CryptoService
 import id.walt.services.did.DidService
+import id.walt.services.jwt.keyId
+
 import java.io.File
 import java.nio.file.Path
 import kotlin.io.path.absolutePathString
@@ -49,20 +53,27 @@ class CreateDidCommand : CliktCommand(
         .choice("key", "web", "ebsi").default("key")
 
     val keyAlias: String? by option("-k", "--key", help = "Specific key (ID or alias)")
-    val domain: String by option("-d", "--domain", help = "Domain for did:web").default("walt.id")
-    val path: String? by option("-p", "--path", help = "Path for did:web")
+    val didWebDomain: String by option("-d", "--domain", help = "Domain for did:web").default("walt.id")
+    val didWebPath: String? by option("-p", "--path", help = "Path for did:web")
+    val didEbsiVersion: Int by option("-v", "--version", help = "Version of did:ebsi. Allowed values: 1 (default), 2").int().default(1)
     val dest: Path? by argument("destination-file").path().optional()
 
     override fun run() {
 
-        val keyId = keyAlias ?: when (method) {
-            "ebsi" -> CryptoService.getService().generateKey(KeyAlgorithm.ECDSA_Secp256k1).id
+        val didMethod = DidMethod.valueOf(method)
+
+        val keyId = keyAlias ?: when (didMethod) {
+            ebsi -> CryptoService.getService().generateKey(KeyAlgorithm.ECDSA_Secp256k1).id
             else -> CryptoService.getService().generateKey(KeyAlgorithm.EdDSA_Ed25519).id
         }
 
         echo("Creating did:${method} (key: ${keyId})")
 
-        val did = DidService.create(DidMethod.valueOf(method), keyId, DidService.DidWebOptions(domain, path))
+        val did = when(didMethod) {
+            web -> DidService.create(web, keyId, DidService.DidWebOptions(didWebDomain, didWebPath))
+            ebsi -> DidService.create(ebsi, keyId, DidService.DidEbsiOptions(didEbsiVersion))
+            key -> DidService.create(key, keyId)
+        }
 
         echo("\nResults:\n")
         echo("\nDID created: $did\n")
@@ -75,10 +86,10 @@ class CreateDidCommand : CliktCommand(
             dest!!.writeText(encodedDid)
         }
 
-        when (method) {
-            "web" -> echo(
-                "\nInstall this did:web at: https://$domain/.well-known/${
-                    path?.replace(":", "/") ?: ""
+        when (didMethod) {
+            web -> echo(
+                "\nInstall this did:web at: https://$didWebDomain/.well-known/${
+                    didWebPath?.replace(":", "/") ?: ""
                 }/did.json"
             )
         }

--- a/src/main/kotlin/id/walt/model/DidUrl.kt
+++ b/src/main/kotlin/id/walt/model/DidUrl.kt
@@ -33,8 +33,11 @@ data class DidUrl(
             return DidUrl(matchResult.groups[1]!!.value, identifierStr, fragmentStr)
         }
 
-        fun generateDidEbsiV2DidUrl() =
+        fun generateDidEbsiV1DidUrl() =
             DidUrl(DidMethod.ebsi.name, "z" + (ByteArray(1) { 0x01.toByte() }.plus(Random.nextBytes(16)).encodeBase58()))
+
+        fun generateDidEbsiV2DidUrl(publicKeyJwkThumbprint: ByteArray) =
+            DidUrl(DidMethod.ebsi.name, "z" + (ByteArray(1) { 0x02.toByte() }.plus(publicKeyJwkThumbprint).encodeBase58()))
 
         fun isDidUrl(url: String): Boolean {
             return PATTERN.toRegex().matches(url)

--- a/src/main/kotlin/id/walt/services/did/DidService.kt
+++ b/src/main/kotlin/id/walt/services/did/DidService.kt
@@ -42,7 +42,7 @@ object DidService {
 
     sealed class DidOptions
     data class DidWebOptions(val domain: String?, val path: String? = null) : DidOptions()
-    data class DidEbsiOptions(val addEidasKey: Boolean, val version: Int) : DidOptions()
+    data class DidEbsiOptions(val version: Int) : DidOptions()
 
 
     private val credentialService = JsonLdCredentialService.getService()

--- a/src/main/kotlin/id/walt/services/did/DidService.kt
+++ b/src/main/kotlin/id/walt/services/did/DidService.kt
@@ -11,6 +11,7 @@ import id.walt.services.context.ContextManager
 import id.walt.services.crypto.CryptoService
 import id.walt.services.hkvstore.HKVKey
 import id.walt.services.key.KeyService
+import id.walt.services.keystore.KeyType
 import id.walt.services.vc.JsonLdCredentialService
 import id.walt.signatory.ProofConfig
 import io.ktor.client.plugins.*
@@ -41,7 +42,7 @@ object DidService {
 
     sealed class DidOptions
     data class DidWebOptions(val domain: String?, val path: String? = null) : DidOptions()
-    data class DidEbsiOptions(val addEidasKey: Boolean) : DidOptions()
+    data class DidEbsiOptions(val addEidasKey: Boolean, val version: Int) : DidOptions()
 
 
     private val credentialService = JsonLdCredentialService.getService()
@@ -119,8 +120,23 @@ object DidService {
         val key = ContextManager.keyStore.load(keyId.id)
 
         // Created identifier
-        val didUrlStr = DidUrl.generateDidEbsiV2DidUrl().did
-        ContextManager.keyStore.addAlias(keyId, didUrlStr)
+        var didUrlStr: String? = didEbsiOptions?.let {
+            when (it.version) {
+                1 -> {
+                    DidUrl.generateDidEbsiV1DidUrl().did
+                }
+                2 -> {
+                    val publicKeyJwk = keyService.toJwk(keyId.id, KeyType.PUBLIC)
+                    val publicKeyJwkThumbprint = publicKeyJwk.computeThumbprint().decode()
+                    DidUrl.generateDidEbsiV2DidUrl(publicKeyJwkThumbprint).did
+                }
+                else -> null
+            }
+        } ?: let {
+            DidUrl.generateDidEbsiV1DidUrl().did
+        }
+
+        ContextManager.keyStore.addAlias(keyId, didUrlStr!!)
 
         // Created DID doc
         val kid = didUrlStr + "#" + key.keyId

--- a/src/test/kotlin/id/walt/services/did/DidServiceTest.kt
+++ b/src/test/kotlin/id/walt/services/did/DidServiceTest.kt
@@ -10,6 +10,7 @@ import id.walt.model.DidMethod
 import id.walt.model.DidUrl
 import id.walt.servicematrix.ServiceMatrix
 import id.walt.services.key.KeyService
+import id.walt.services.keystore.KeyType
 import id.walt.test.RESOURCES_PATH
 import io.kotest.assertions.json.shouldMatchJson
 import io.kotest.assertions.throwables.shouldThrow
@@ -96,13 +97,28 @@ class DidServiceTest : AnnotationSpec() {
     }
 
     @Test
-    fun createDidEbsiV2Identifier() {
-        val didUrl = DidUrl.generateDidEbsiV2DidUrl()
+    fun createDidEbsiV1Identifier() {
+        val didUrl = DidUrl.generateDidEbsiV1DidUrl()
         val did = didUrl.did
         did.substring(0, 9) shouldBe  "did:ebsi:"
         didUrl.identifier.length shouldBeOneOf listOf(23, 24)
         didUrl.identifier[0] shouldBe 'z'
         didUrl.identifier.substring(1).decodeBase58()[0] shouldBe 0x01
+        didUrl.method shouldBe "ebsi"
+    }
+
+    @Test
+    fun createDidEbsiV2Identifier() {
+        val keyService = KeyService.getService()
+        val keyId = keyService.generate(KeyAlgorithm.ECDSA_Secp256k1)
+        val publicKeyJwk = keyService.toJwk(keyId.id, KeyType.PUBLIC)
+        val publicKeyJwkThumbprint = publicKeyJwk.computeThumbprint().decode()
+        val didUrl = DidUrl.generateDidEbsiV2DidUrl(publicKeyJwkThumbprint)
+        val did = didUrl.did
+        did.substring(0, 9) shouldBe  "did:ebsi:"
+        didUrl.identifier.length shouldBe 45
+        didUrl.identifier[0] shouldBe 'z'
+        didUrl.identifier.substring(1).decodeBase58()[0] shouldBe 0x02
         didUrl.method shouldBe "ebsi"
     }
 


### PR DESCRIPTION
I implemented the EBSI Method V2 following: https://ec.europa.eu/digital-building-blocks/wikis/display/EBSIDOC/EBSI+DID+Method#EBSIDIDMethod-NaturalPersonspublickeymaterialsarehashed(sha-256)intotheDIDMethodasJWKThumbprint.TobeabletovalidateanyDIDV2,theholdermustalwaysusejwkfieldinJWTHeadertocarrythepublickeymaterials.DIDDocumentforEBSIDIDV2

It seems that EBSI DID Method V2 is going to coexist with the method V1. The V2 will be used by Natural Persons, so they can avoid the anchoring of the DID in the ledger, and the V1 will still be used by Legal Entities.