### PR TITLE
Ensure correct line endings

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,9 +17,16 @@ VOLUME /home/gradle/.gradle
 WORKDIR /opt
 
 RUN apt-get update && apt-get upgrade --yes
+RUN apt-get install -y dos2unix
 
 FROM openjdk-gradle AS walt-build
 COPY ./ /opt
+
+# When running docker build on Windows, make sure these have
+# the right line endings
+
+RUN dos2unix ./gradlew src/test/resources/key/*.pem
+
 RUN ./gradlew clean build
 RUN tar xf /opt/build/distributions/waltid-ssi-kit-*.tar -C /opt
 


### PR DESCRIPTION
Ensures that line endings for gradlew and *.pem files are correct in the Docker image, even when building docker image form Windows (where *.pem files need to have crlf endings when building on Win natively).

Verified by:
* Building docker on Windows
* Building docker on Linux
* Building natively on Windows
* 