### PR TITLE
Support policies with optional arguments

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -110,6 +110,8 @@ dependencies {
     testImplementation("io.kotest:kotest-runner-junit5:5.5.4")
     testImplementation("io.kotest:kotest-assertions-core:5.5.4")
     testImplementation("io.kotest:kotest-assertions-json:5.5.4")
+
+    testImplementation("org.junit.jupiter:junit-jupiter:5.9.2")
 }
 
 tasks.withType<Test> {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -111,7 +111,6 @@ dependencies {
     testImplementation("io.kotest:kotest-assertions-core:5.5.4")
     testImplementation("io.kotest:kotest-assertions-json:5.5.4")
 
-    testImplementation("org.junit.jupiter:junit-jupiter:5.9.2")
 }
 
 tasks.withType<Test> {

--- a/src/main/kotlin/id/walt/auditor/PolicyRegistry.kt
+++ b/src/main/kotlin/id/walt/auditor/PolicyRegistry.kt
@@ -173,7 +173,12 @@ object PolicyRegistry {
         //register(JsonSchemaPolicy::class, "Verify by JSON schema")
         register(TrustedSchemaRegistryPolicy::class, "Verify by EBSI Trusted Schema Registry")
         register(TrustedIssuerDidPolicy::class, "Verify by trusted issuer did")
-        register(TrustedIssuerRegistryPolicy::class, "Verify by trusted EBSI Trusted Issuer Registry record")
+        register(TrustedIssuerRegistryPolicy::class, "Verify by EBSI Trusted Issuer Registry record")
+        register(
+            ParameterizedTrustedIssuerRegistryPolicy::class,
+            TrustedIssuerRegistryPolicyArg::class,
+            "Verify by an EBSI Trusted Issuers Registry compliant api."
+        )
         register(TrustedSubjectDidPolicy::class, "Verify by trusted subject did")
         register(IssuedDateBeforePolicy::class, "Verify by issuance date")
         register(ValidFromBeforePolicy::class, "Verify by valid from")

--- a/src/main/kotlin/id/walt/services/ecosystems/essif/TrustedIssuerClient.kt
+++ b/src/main/kotlin/id/walt/services/ecosystems/essif/TrustedIssuerClient.kt
@@ -112,15 +112,23 @@ object TrustedIssuerClient {
         return@runBlocking trustedIssuer
     }
 
-    fun getIssuer(did: String): TrustedIssuer = runBlocking {
+
+    fun getIssuer(did: String, registryAddress: String): TrustedIssuer = runBlocking {
         log.debug { "Getting trusted issuer with DID $did" }
 
+        val registryUrl = registryAddress + did
+
         val trustedIssuer: String =
-            WaltIdServices.http.get("https://api-pilot.ebsi.eu/trusted-issuers-registry/v2/issuers/$did").bodyAsText()
+            WaltIdServices.http.get(registryUrl).bodyAsText()
 
         log.debug { trustedIssuer }
 
         return@runBlocking Klaxon().parse<TrustedIssuer>(trustedIssuer)!!
+    }
+
+    fun getIssuer(did: String): TrustedIssuer = runBlocking {
+        log.debug { "Getting trusted issuer with DID $did" }
+        return@runBlocking getIssuer(did, "https://api-pilot.ebsi.eu/trusted-issuers-registry/v2/issuers/")
     }
 
     ///////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/test/kotlin/id/walt/auditor/PolicyFactoryTest.kt
+++ b/src/test/kotlin/id/walt/auditor/PolicyFactoryTest.kt
@@ -1,0 +1,53 @@
+package id.walt.auditor
+
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.AnnotationSpec
+import io.kotest.matchers.should
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.types.beInstanceOf
+import io.kotest.matchers.types.shouldBeInstanceOf
+import org.junit.jupiter.api.Assertions.assertAll
+
+class PolicyFactoryTest : AnnotationSpec() {
+
+    private val testArgument = TrustedIssuerRegistryPolicyArg("testArg")
+    private val wrongArg = AnotherArg("Else")
+    private val defaultARg = TrustedIssuerRegistryPolicyArg("https://api-pilot.ebsi.eu/trusted-issuers-registry/v2/issuers/")
+
+    @Test
+    fun createTrustedIssuerRegistryPolicyWithoutOptionalArg() {
+        val factoryToTest =
+            PolicyFactory(TrustedIssuerRegistryPolicy::class, TrustedIssuerRegistryPolicyArg::class, "testPolicy", null, false)
+
+        assertAll(
+            { factoryToTest.create(testArgument).argument shouldBe testArgument },
+            { shouldThrow<IllegalArgumentException> { factoryToTest.create() } },
+            { shouldThrow<IllegalArgumentException> { factoryToTest.create(wrongArg) } }
+        )
+    }
+
+    @Test
+    fun createTrustedIssuerRegistryPolicyWithOptionalArg() {
+        val factoryToTest =
+            PolicyFactory(TrustedIssuerRegistryPolicy::class, TrustedIssuerRegistryPolicyArg::class, "testPolicy", null, true)
+        assertAll(
+            { factoryToTest.create(testArgument).argument shouldBe testArgument },
+            { factoryToTest.create().argument shouldBe defaultARg },
+            { shouldThrow<IllegalArgumentException> { factoryToTest.create(wrongArg) } }
+        )
+    }
+
+    @Test
+    fun createSimplePolicy() {
+        val factoryToTest =
+            PolicyFactory<SignaturePolicy, Unit>(SignaturePolicy::class, null, "testPolicy", null)
+
+        assertAll(
+            { factoryToTest.create() should beInstanceOf<SignaturePolicy>() },
+            { factoryToTest.create(testArgument) shouldBe beInstanceOf<SignaturePolicy>() }
+        )
+    }
+}
+
+
+data class AnotherArg(val somethingElse: String)

--- a/src/test/kotlin/id/walt/auditor/PolicyFactoryTest.kt
+++ b/src/test/kotlin/id/walt/auditor/PolicyFactoryTest.kt
@@ -5,7 +5,6 @@ import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.matchers.should
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.types.beInstanceOf
-import io.kotest.matchers.types.shouldBeInstanceOf
 import org.junit.jupiter.api.Assertions.assertAll
 
 class PolicyFactoryTest : AnnotationSpec() {

--- a/src/test/kotlin/id/walt/auditor/TrustedIssuerRegistryPolicyTest.kt
+++ b/src/test/kotlin/id/walt/auditor/TrustedIssuerRegistryPolicyTest.kt
@@ -20,7 +20,6 @@ import io.mockk.mockkObject
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.Arguments
 import org.junit.jupiter.params.provider.MethodSource
-import org.junit.jupiter.params.provider.ValueSource
 import java.util.stream.Stream
 
 class TrustedIssuerRegistryPolicyTest : AnnotationSpec() {

--- a/src/test/kotlin/id/walt/auditor/TrustedIssuerRegistryPolicyTest.kt
+++ b/src/test/kotlin/id/walt/auditor/TrustedIssuerRegistryPolicyTest.kt
@@ -15,14 +15,18 @@ import id.walt.signatory.Signatory
 import io.kotest.core.spec.style.AnnotationSpec
 import io.kotest.core.test.TestCase
 import io.kotest.matchers.shouldBe
+import io.mockk.CapturingSlot
 import io.mockk.every
 import io.mockk.mockkObject
-import org.junit.jupiter.params.ParameterizedTest
-import org.junit.jupiter.params.provider.Arguments
-import org.junit.jupiter.params.provider.MethodSource
-import java.util.stream.Stream
+import org.junit.jupiter.api.assertAll
 
 class TrustedIssuerRegistryPolicyTest : AnnotationSpec() {
+
+    private val defaultRegistry = "https://api-pilot.ebsi.eu/trusted-issuers-registry/v2/issuers/"
+    private val otherRegistry = "http://my-other-registry.org/v3/issuers/"
+
+    private val simplePolicy = TrustedIssuerRegistryPolicy();
+    private val parameterizedPolicy = TrustedIssuerRegistryPolicy(otherRegistry);
 
     private val mockedHash = "mockHash"
     private val validAttrInfoJson =
@@ -56,47 +60,59 @@ class TrustedIssuerRegistryPolicyTest : AnnotationSpec() {
         verifiableCredential = vcStr.toVerifiableCredential()
     }
 
-    @ParameterizedTest
-    @MethodSource("id.walt.auditor.TrustedIssuerRegistryPolicyTest#provideTestPolicies")
-    fun whenTrustedIssuerRegistryContainsValidAttributeThenReturnTrue(policy : VerificationPolicy) {
+    @Test
+    fun whenTrustedIssuerRegistryContainsValidAttributeThenReturnTrue() {
         val attributeList = listOf(Attribute(mockedHash, encBase64Str(validAttrInfoJson)))
-        mockTrustedIssuerWithAttributes(attributeList)
+        val capture = mockTrustedIssuerWithAttributes(attributeList)
 
-        policy.verify(verifiableCredential) shouldBe true
-    }
-
-    fun provideTestPolicies(): Stream<Arguments> {
-        return Stream.of(
-            Arguments.of(TrustedIssuerRegistryPolicy()),
-            Arguments.of(TrustedIssuerRegistryPolicy("http://my-other-registry.org/v3/issuers/"))
+        assertAll(
+            { simplePolicy.verify(verifiableCredential) shouldBe true },
+            { capture.captured shouldBe defaultRegistry }
         )
 
+        assertAll(
+            { parameterizedPolicy.verify(verifiableCredential) shouldBe true },
+            { capture.captured shouldBe otherRegistry }
+        )
     }
 
-    @ParameterizedTest
-    @MethodSource("id.walt.auditor.TrustedIssuerRegistryPolicyTest#provideTestPolicies")
-    fun whenTrustedIssuerRegistryContainsInvalidBase64AttributeThenReturnFalse(policy : VerificationPolicy) {
+
+    @Test
+    fun whenTrustedIssuerRegistryContainsInvalidBase64AttributeThenReturnFalse() {
         val attributeList = listOf(Attribute(mockedHash, "invalidBase64EncodedString"))
         mockTrustedIssuerWithAttributes(attributeList)
 
-        policy.verify(verifiableCredential) shouldBe false
+        assertAll(
+            { simplePolicy.verify(verifiableCredential) shouldBe false },
+            { parameterizedPolicy.verify(verifiableCredential) shouldBe false }
+        )
     }
 
-    @ParameterizedTest
-    @MethodSource("id.walt.auditor.TrustedIssuerRegistryPolicyTest#provideTestPolicies")
-    fun whenTrustedIssuerRegistryContainsMultipleAttributesWithLastValidThenReturnTrue(policy : VerificationPolicy) {
+    @Test
+    fun whenTrustedIssuerRegistryContainsMultipleAttributesWithLastValidThenReturnTrue() {
         val attr1 = Attribute(mockedHash, "invalidBase64EncodedString")
         val attr2 = Attribute(mockedHash, encBase64Str("invalidAttr"))
         val attr3 = Attribute(mockedHash, encBase64Str(validAttrInfoJson))
         val attributeList = listOf(attr1, attr2, attr3)
-        mockTrustedIssuerWithAttributes(attributeList)
+        val capture = mockTrustedIssuerWithAttributes(attributeList)
 
-        policy.verify(verifiableCredential) shouldBe true
+        assertAll(
+            { simplePolicy.verify(verifiableCredential) shouldBe true },
+            { capture.captured shouldBe defaultRegistry }
+        )
+
+        assertAll(
+            { parameterizedPolicy.verify(verifiableCredential) shouldBe true },
+            { capture.captured shouldBe otherRegistry }
+        )
+
     }
 
-    private fun mockTrustedIssuerWithAttributes(attributeList: List<Attribute>) {
+    private fun mockTrustedIssuerWithAttributes(attributeList: List<Attribute>): CapturingSlot<String> {
         val tirRecord = TrustedIssuer(did, attributeList)
+        val slot = CapturingSlot<String>()
         mockkObject(TrustedIssuerClient)
-        every { TrustedIssuerClient.getIssuer(any(), any()) } returns tirRecord
+        every { TrustedIssuerClient.getIssuer(any(), capture(slot)) } returns tirRecord
+        return slot
     }
 }


### PR DESCRIPTION
In order to support the usage of TrusteIssuerRegistries other than "https://api-pilot.ebsi.eu/trusted-issuers-registry/v2/issuers/" I extended the TrustedIssuerRegistryPolicy and the PolicyFactory to support policies with optional arguments. This allows the usage of the same policy in a context of dataspaces, which bring a more restricted but api-compatible tir, while still beeing backward compatible.

Please let me know if you think thats a good way to support such scenarios.

Beside that, I have two related questions(that I could put into an issue if you prefer): 
- the current implementation does only allow one instance of a policy per verification request(due to the usage of simple-name as a map key) - I can forsee usecases where I want to use the same policy verified with different parameters. Is this something you would support in the future?
- the TrustedIssuerRegistryPolicy checks for the existence of a specifically formatted attribute (e.g. {name: issuer}). This is not mandated by the ebsi-spec. Why did you decide to do so?

Best,
Stefan