### PR TITLE
re-enable JsonSchemaPolicy optionally with argument to define schema …

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -52,7 +52,7 @@ dependencies {
     implementation("com.beust:klaxon:5.6")
     implementation("com.fasterxml.jackson.datatype:jackson-datatype-jsr310:2.14.0")
     implementation("com.jayway.jsonpath:json-path:2.7.0")
-    implementation("com.networknt:json-schema-validator:1.0.73")
+    implementation("com.networknt:json-schema-validator:1.0.77")
     implementation("net.pwall.json:json-kotlin-schema:0.39")
 
     implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1")

--- a/src/main/kotlin/id/walt/auditor/PolicyRegistryService.kt
+++ b/src/main/kotlin/id/walt/auditor/PolicyRegistryService.kt
@@ -42,6 +42,12 @@ open class PolicyRegistryService: WaltIdService() {
         optionalArgument: Boolean = false
     ) = policies.put(policy.simpleName!!, PolicyFactory(policy, argType, policy.simpleName!!, description, optionalArgument))
 
+    fun <P : OptionalParameterizedVerificationPolicy<A>, A : Any> register(
+        policy: KClass<P>,
+        argType: KClass<A>,
+        description: String? = null
+    ) = policies.put(policy.simpleName!!, PolicyFactory(policy, argType, policy.simpleName!!, description, true))
+
     fun <P : SimpleVerificationPolicy> register(policy: KClass<P>, description: String? = null) =
         policies.put(policy.simpleName!!, PolicyFactory<P, Unit>(policy, null, policy.simpleName!!, description))
 
@@ -132,7 +138,7 @@ open class PolicyRegistryService: WaltIdService() {
 
     open fun initPolicies() {
         register(SignaturePolicy::class, "Verify by signature")
-        //register(JsonSchemaPolicy::class, "Verify by JSON schema")
+        register(JsonSchemaPolicy::class, JsonSchemaPolicyArg::class, "Verify by JSON schema")
         register(TrustedSchemaRegistryPolicy::class, "Verify by EBSI Trusted Schema Registry")
         register(TrustedIssuerDidPolicy::class, "Verify by trusted issuer did")
         PolicyRegistry.register(

--- a/src/main/kotlin/id/walt/auditor/VerificationPolicy.kt
+++ b/src/main/kotlin/id/walt/auditor/VerificationPolicy.kt
@@ -57,7 +57,7 @@ abstract class SimpleVerificationPolicy : VerificationPolicy()
 
 abstract class ParameterizedVerificationPolicy<T>(val argument: T) : VerificationPolicy()
 
-abstract class OptionalParameterizedVerificationPolicy<T>(val argument: T?) : VerificationPolicy()
+abstract class OptionalParameterizedVerificationPolicy<T>(argument: T?) : ParameterizedVerificationPolicy<T?>(argument)
 
 class SignaturePolicy : SimpleVerificationPolicy() {
     override val description: String = "Verify by signature"
@@ -72,10 +72,17 @@ class SignaturePolicy : SimpleVerificationPolicy() {
     }.getOrDefault(false)
 }
 
-class JsonSchemaPolicy : SimpleVerificationPolicy() {
+/**
+ * @param schema    URL, file path or content of JSON schema to validate against
+ */
+data class JsonSchemaPolicyArg(val schema: String)
+
+class JsonSchemaPolicy(schemaPolicyArg: JsonSchemaPolicyArg?) : OptionalParameterizedVerificationPolicy<JsonSchemaPolicyArg>(schemaPolicyArg) {
+    constructor() : this(null)
+
     override val description: String = "Verify by JSON schema"
     override fun doVerify(vc: VerifiableCredential): Boolean {
-        return vc.credentialSchema?.id?.let { URI.create(it) }?.let {
+        return (argument?.schema ?: vc.credentialSchema?.id)?.let {
             SchemaValidatorFactory.get(it).validate(vc.toJson())
         } ?: false
     }

--- a/src/main/kotlin/id/walt/credentials/w3c/schema/SchemaValidatorFactory.kt
+++ b/src/main/kotlin/id/walt/credentials/w3c/schema/SchemaValidatorFactory.kt
@@ -2,6 +2,7 @@ package id.walt.credentials.w3c.schema
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.networknt.schema.SpecVersion.VersionFlag.*
+import id.walt.common.resolveContent
 import java.net.URI
 
 object SchemaValidatorFactory {
@@ -10,13 +11,17 @@ object SchemaValidatorFactory {
 
     fun get(schema: URI): SchemaValidator = get(schema.toURL().readText())
 
-    fun get(schema: String): SchemaValidator = with(mapper.readTree(schema).get("\$schema").asText()) {
-        return when {
-            contains("2019-09") -> NetworkntSchemaValidator(V201909, schema)
-            contains("draft-07") -> NetworkntSchemaValidator(V7, schema)
-            contains("draft-06") -> NetworkntSchemaValidator(V6, schema)
-            contains("draft-04") -> NetworkntSchemaValidator(V4, schema)
-            else -> PWallSchemaValidator(schema)
+    fun get(schemaUrlFileOrContent: String): SchemaValidator {
+        val schema = resolveContent(schemaUrlFileOrContent)
+        with(mapper.readTree(schema).get("\$schema").asText()) {
+            return when {
+                contains("2020-12") -> NetworkntSchemaValidator(V202012, schema)
+                contains("2019-09") -> NetworkntSchemaValidator(V201909, schema)
+                contains("draft-07") -> NetworkntSchemaValidator(V7, schema)
+                contains("draft-06") -> NetworkntSchemaValidator(V6, schema)
+                contains("draft-04") -> NetworkntSchemaValidator(V4, schema)
+                else -> PWallSchemaValidator(schema)
+            }
         }
     }
 }

--- a/src/main/resources/vc-templates/VerifiableDiploma.json
+++ b/src/main/resources/vc-templates/VerifiableDiploma.json
@@ -1,7 +1,7 @@
 {
   "@context": ["https://www.w3.org/2018/credentials/v1"],
   "credentialSchema": {
-    "id": "https://api.preprod.ebsi.eu/trusted-schemas-registry/v1/schemas/0xbf78fc08a7a9f28f5479f58dea269d3657f54f13ca37d380cd4e92237fb691dd",
+    "id": "https://raw.githubusercontent.com/walt-id/waltid-ssikit-vclib/master/src/test/resources/schemas/VerifiableDiploma.json",
     "type": "JsonSchemaValidator2018"
   },
   "credentialStatus": {


### PR DESCRIPTION
…to validate against, from file path, URL or by value

re-enable auditor tests that had been disabled
support schema 2020-12 in schema validator factory update networknt schema validation lib