### PR TITLE
Introduced jwtPayloadUpdate in proof config

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 }
 
 group = "id.walt"
-version = "1.SNAPSHOT"
+version = "1.1.1"
 
 repositories {
     mavenCentral()

--- a/src/main/kotlin/id/walt/services/vc/WaltIdJwtCredentialService.kt
+++ b/src/main/kotlin/id/walt/services/vc/WaltIdJwtCredentialService.kt
@@ -11,6 +11,7 @@ import id.walt.sdjwt.SDPayload
 import id.walt.sdjwt.toSDMap
 import id.walt.services.did.DidService
 import id.walt.services.jwt.JwtService
+import id.walt.signatory.JwtPayloadUpdate
 import id.walt.signatory.ProofConfig
 import id.walt.signatory.ProofType
 import kotlinx.serialization.json.Json
@@ -38,7 +39,7 @@ open class WaltIdJwtCredentialService : JwtCredentialService() {
         val issuerDid = config.issuerDid
         val issueDate = config.issueDate ?: Instant.now()
         val validDate = config.validDate ?: Instant.now()
-        val jwtClaimsSet = JWTClaimsSet.Builder()
+        var jwtClaimsSet = JWTClaimsSet.Builder()
             .jwtID(config.credentialId)
             .issuer(issuerDid)
             .subject(config.subjectDid)
@@ -54,6 +55,10 @@ open class WaltIdJwtCredentialService : JwtCredentialService() {
         val vcClaim = when (crd) {
             is VerifiablePresentation -> JWT_VP_CLAIM
             else -> JWT_VC_CLAIM
+        }
+
+        if (config.jwtPayloadUpdate == JwtPayloadUpdate.NO) {
+            jwtClaimsSet = JWTClaimsSet.Builder()
         }
 
         jwtClaimsSet.claim(vcClaim, JsonConverter.fromJsonElement(crd.toJsonObject()))

--- a/src/main/kotlin/id/walt/signatory/Signatory.kt
+++ b/src/main/kotlin/id/walt/signatory/Signatory.kt
@@ -29,6 +29,11 @@ enum class Ecosystem {
     IOTA
 }
 
+enum class JwtPayloadUpdate {
+    YES, // Will updated the payload at JWT Credentials with the claim-set according the EBSI specs
+    NO
+}
+
 data class ProofConfig(
     val issuerDid: String,
     @Json(serializeNull = false) val subjectDid: String? = null,
@@ -49,7 +54,8 @@ data class ProofConfig(
     @Json(serializeNull = false) val statusType: CredentialStatus.Types? = null,
     @Json(serializeNull = false) val statusPurpose: String = "revocation",
     @Json(serializeNull = false) val credentialsEndpoint: String? = null,
-    @Json(serializeNull = false) @SDMapProperty val selectiveDisclosure: SDMap? = null
+    @Json(serializeNull = false) @SDMapProperty val selectiveDisclosure: SDMap? = null,
+    @Json(serializeNull = false) val jwtPayloadUpdate: JwtPayloadUpdate? = JwtPayloadUpdate.YES,
 )
 
 data class SignatoryConfig(

--- a/src/main/kotlin/id/walt/signatory/WaltIdSignatory.kt
+++ b/src/main/kotlin/id/walt/signatory/WaltIdSignatory.kt
@@ -71,7 +71,8 @@ class WaltIdSignatory(configurationPath: String) : Signatory() {
             statusPurpose = config.statusPurpose,
             statusType = config.statusType,
             credentialsEndpoint = config.credentialsEndpoint,
-            selectiveDisclosure = config.selectiveDisclosure
+            selectiveDisclosure = config.selectiveDisclosure,
+            jwtPayloadUpdate = config.jwtPayloadUpdate
         )
     }
 
@@ -100,15 +101,19 @@ class WaltIdSignatory(configurationPath: String) : Signatory() {
     ): String {
         val fullProofConfig = fillProofConfig(config)
         val vcRequest = credentialBuilder.apply {
-            issuer?.let { setIssuer(it) }
-            setIssuerId(fullProofConfig.issuerDid)
-            setIssuanceDate(fullProofConfig.issueDate ?: Instant.now())
-            setIssued(fullProofConfig.issueDate ?: Instant.now())
-            fullProofConfig.subjectDid?.let { setSubjectId(it) }
-            setId(fullProofConfig.credentialId.orEmpty().ifEmpty { "urn:uuid:${UUID.randomUUID()}" })
-            setIssuanceDate(fullProofConfig.issueDate ?: Instant.now())
-            setValidFrom(fullProofConfig.validDate ?: Instant.now())
-            fullProofConfig.expirationDate?.let { setExpirationDate(it) }
+
+            if (config.jwtPayloadUpdate == JwtPayloadUpdate.YES) {
+                issuer?.let { setIssuer(it) }
+                setIssuerId(fullProofConfig.issuerDid)
+                setIssuanceDate(fullProofConfig.issueDate ?: Instant.now())
+                setIssued(fullProofConfig.issueDate ?: Instant.now())
+                fullProofConfig.subjectDid?.let { setSubjectId(it) }
+                setId(fullProofConfig.credentialId.orEmpty().ifEmpty { "urn:uuid:${UUID.randomUUID()}" })
+                setIssuanceDate(fullProofConfig.issueDate ?: Instant.now())
+                setValidFrom(fullProofConfig.validDate ?: Instant.now())
+                fullProofConfig.expirationDate?.let { setExpirationDate(it) }
+            }
+
         }.let { builder ->
             config.statusType?.let {
                 W3CCredentialBuilderWithCredentialStatus(builder, config)


### PR DESCRIPTION
In order to make the payload-modification with the derault JWT claimset for JWT-based credentials configurable, a new config-flag got introduced.